### PR TITLE
fix: replace OG image url

### DIFF
--- a/src/slots/SEO.tsx
+++ b/src/slots/SEO.tsx
@@ -17,15 +17,15 @@ export const SEO: React.FC<SEOProps> = ({
   title,
   titleSuffix,
 }) => {
-  const { themeConfig } = useSiteData()
-  const { title: defaultTitle, defaultDescription } = themeConfig
+  const { themeConfig } = useSiteData();
+  const { title: defaultTitle, description: defaultDescription } = themeConfig;
 
   const metaDescription = description || defaultDescription;
 
   return (
     <Helmet
       htmlAttributes={{
-        lang
+        lang,
       }}
       title={title}
       titleTemplate={`%s | ${titleSuffix || defaultTitle}`}
@@ -45,7 +45,7 @@ export const SEO: React.FC<SEOProps> = ({
         {
           property: `og:image`,
           content:
-            'https://gw.alipayobjects.com/zos/antfincdn/FLrTNDvlna/antv.png',
+            'https://s3-gzpu.didistatic.com/ese-feedback/LogicFlow/2.0HeadImg.png',
         },
         {
           property: `og:type`,
@@ -66,7 +66,7 @@ export const SEO: React.FC<SEOProps> = ({
         {
           property: `twitter:image`,
           content:
-            'https://gw.alipayobjects.com/zos/antfincdn/FLrTNDvlna/antv.png',
+            'https://s3-gzpu.didistatic.com/ese-feedback/LogicFlow/2.0HeadImg.png',
         },
       ].concat(meta)}
     />


### PR DESCRIPTION
修复官网在其他平台上的链接展示效果，现在链接的封面图为 antv 的 logo，修改后变成 LF 官网的头图，且支持 description。

修改前：
<img width="276" alt="image" src="https://github.com/user-attachments/assets/19ee47fb-d5ff-492e-8d40-d7bcd55a1ff2" />

修改后：
<img width="276" alt="image" src="https://github.com/user-attachments/assets/d04c4542-a969-4fee-b7a1-863691bf324e" />
